### PR TITLE
Add CSS to index form

### DIFF
--- a/static/css/form.css
+++ b/static/css/form.css
@@ -1,0 +1,5 @@
+pre {
+    background-color: #eee;
+    padding: 8px;
+    font-size: 2em;
+}

--- a/views/_css.pug
+++ b/views/_css.pug
@@ -1,0 +1,1 @@
+link(rel="stylesheet" href="css/form.css")

--- a/views/_wrapper.pug
+++ b/views/_wrapper.pug
@@ -2,5 +2,6 @@ doctype html
 html
     head
         title Pseudo-random numbers
+        include _css.pug
         include _js.pug
     body


### PR DESCRIPTION
Adds styling to the `pre` tag in the random number view.

![image](https://user-images.githubusercontent.com/3380818/146531924-522b00ef-565b-4c34-8497-4a1221472794.png)
